### PR TITLE
Fix min sdk version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,8 +39,7 @@ android {
     }
     productFlavors {
         envDev {
-            // minSdkVersion を 21 以上にしておくとビルドが速くなるので、開発時には minSdkVersion を 21 にしておく
-            minSdkVersion 21
+            minSdkVersion 19
             buildConfigField "boolean", "FIREBASE_ENABLED", "false"
         }
         envProd {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,6 @@ android {
     }
     productFlavors {
         envDev {
-            minSdkVersion 19
             buildConfigField "boolean", "FIREBASE_ENABLED", "false"
         }
         envProd {

--- a/app/src/main/kotlin/com/tumpaca/tumpaca/fragment/post/PostFragment.kt
+++ b/app/src/main/kotlin/com/tumpaca/tumpaca/fragment/post/PostFragment.kt
@@ -2,6 +2,7 @@ package com.tumpaca.tumpaca.fragment.post
 
 import android.content.BroadcastReceiver
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.webkit.WebView
@@ -53,8 +54,9 @@ abstract class PostFragment : FragmentBase() {
         val mimeType = "text/html; charset=utf-8"
         subTextView.setBackgroundColor(Color.TRANSPARENT)
         subTextView.loadData(subText, mimeType, null)
-        subTextView.clipToOutline = true
-
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            subTextView.clipToOutline = true
+        }
 
         val rebloggedView = view.findViewById(R.id.reblogged) as TextView
         if (reblogged != null) {

--- a/app/src/main/kotlin/com/tumpaca/tumpaca/util/TPToastManager.kt
+++ b/app/src/main/kotlin/com/tumpaca/tumpaca/util/TPToastManager.kt
@@ -19,20 +19,20 @@ object TPToastManager {
     fun show(msg: String) {
         val frameLayout = object : FrameLayout(TPRuntime.mainApplication) {
             override public fun onDetachedFromWindow() {
-                super.onDetachedFromWindow();
-                toastCounts = toastCounts - 1
+                super.onDetachedFromWindow()
+                toastCounts -= 1
             }
-        };
+        }
         synchronized(this, {
-            val toast = Toast(TPRuntime.mainApplication);
+            val toast = Toast(TPRuntime.mainApplication)
             toast.duration = Toast.LENGTH_SHORT
             val inflater = TPRuntime.mainApplication.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
             val layout = inflater.inflate(R.layout.toast, null)
             val textView = layout.findViewById(R.id.tp_toast_text) as TextView
-            textView.setText(msg)
+            textView.text = msg
             toast.view = layout
 
-            frameLayout.addView(toast.getView())
+            frameLayout.addView(toast.view)
             toast.view = frameLayout
 
             //val location = intArrayOf(0, 0)
@@ -41,8 +41,8 @@ object TPToastManager {
             //Log.v("TPToastManager", "location x=${location.get(0)}, y=${location.get(1)}")
             //toast.setGravity(Gravity.RIGHT or Gravity.TOP, 16, 10 + location.get(1))
             toast.setGravity(Gravity.RIGHT or Gravity.TOP, 16, 10)
-            toast.show();
-            toastCounts = toastCounts + 1
+            toast.show()
+            toastCounts += 1
         })
     }
 

--- a/app/src/main/kotlin/com/tumpaca/tumpaca/view/TPWebViewClient.kt
+++ b/app/src/main/kotlin/com/tumpaca/tumpaca/view/TPWebViewClient.kt
@@ -17,9 +17,13 @@ class TPWebViewClient(val cssFilePath: String) : WebViewClient() {
      * WebView内のリンクをタップしたときは、外部ブラウザを立ち上げる
      */
     override fun shouldOverrideUrlLoading(view: WebView, url: String?): Boolean {
-        if (url != null && (url.startsWith("http://") || url.startsWith("https://"))) {
-            view.context.startActivity(
-                    Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        if (url != null) {
+            try {
+                view.context.startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+            } catch (e: Exception) {
+                return false
+            }
             return true
         } else {
             return false


### PR DESCRIPTION
ビルド高速化のためにminSdkVersionが21 (Lollipop) になっていたのを19に戻しました。

それに伴いAndroid 4.4で動かしてみたら、いくつかsdk version 19では使えないメソッドを使っているために、落ちてしまったので、そこも修正しました。