### PR TITLE
リブログやライク後すぐに設定からリロードすると落ちる問題を修正

### DIFF
--- a/app/src/main/kotlin/com/tumpaca/tumpaca/fragment/DashboardFragment.kt
+++ b/app/src/main/kotlin/com/tumpaca/tumpaca/fragment/DashboardFragment.kt
@@ -130,23 +130,26 @@ class DashboardFragment : FragmentBase() {
     }
 
     private fun doLike() {
-        currentPost?.likeAsync({ post ->
+        currentPost?.likeAsync(resources.getString(R.string.liked_result), resources.getString(R.string.unliked_result), { post, likeMsg, unlikeMsg ->
             // ここまで来ると違うPostが表示されているかもしれないのでチェック
             currentPost?.let {
                 if (it == post) {
                     toggleLikeButton(post)
                 }
             }
-            val msg = if (post.isLiked) R.string.liked_result else R.string.unliked_result
-            TPToastManager.show(resources.getString(msg))
+            if (post.isLiked) {
+                TPToastManager.show(likeMsg)
+            } else {
+                TPToastManager.show(unlikeMsg)
+            }
         })
     }
 
     private fun doReblog() {
         val post = currentPost!!
         val blogName = TPRuntime.tumblrService.user?.blogs?.first()?.name!!
-        post.reblogAsync(blogName, null, {
-            TPToastManager.show(resources.getString(R.string.reblogged_result))
+        post.reblogAsync(blogName, resources.getString(R.string.reblogged_result), null, { post, msg ->
+            TPToastManager.show(msg)
         })
 
         /** TODO 設定画面でリブログ時のコメント追加 on/off が出来るようになったら復活

--- a/app/src/main/kotlin/com/tumpaca/tumpaca/fragment/DashboardFragment.kt
+++ b/app/src/main/kotlin/com/tumpaca/tumpaca/fragment/DashboardFragment.kt
@@ -130,7 +130,9 @@ class DashboardFragment : FragmentBase() {
     }
 
     private fun doLike() {
-        currentPost?.likeAsync(resources.getString(R.string.liked_result), resources.getString(R.string.unliked_result), { post, likeMsg, unlikeMsg ->
+        val likeMsg = resources.getString(R.string.liked_result)
+        val unlikeMsg = resources.getString(R.string.unliked_result)
+        currentPost?.likeAsync({ post ->
             // ここまで来ると違うPostが表示されているかもしれないのでチェック
             currentPost?.let {
                 if (it == post) {
@@ -148,7 +150,8 @@ class DashboardFragment : FragmentBase() {
     private fun doReblog() {
         val post = currentPost!!
         val blogName = TPRuntime.tumblrService.user?.blogs?.first()?.name!!
-        post.reblogAsync(blogName, resources.getString(R.string.reblogged_result), null, { post, msg ->
+        val msg = resources.getString(R.string.reblogged_result)
+        post.reblogAsync(blogName, null, { post ->
             TPToastManager.show(msg)
         })
 

--- a/app/src/main/kotlin/com/tumpaca/tumpaca/util/Extensions.kt
+++ b/app/src/main/kotlin/com/tumpaca/tumpaca/util/Extensions.kt
@@ -21,14 +21,13 @@ fun Context.editSharedPreferences(name: String, mode: Int = Context.MODE_PRIVATE
     assert(committed)
 }
 
-fun Post.likeAsync(likeMsg: String, unlikeMsg: String, callback: (Post, String, String) -> Unit) {
+fun Post.likeAsync(callback: (Post) -> Unit) {
     if (this.isLiked) {
         TPToastManager.show(TPRuntime.mainApplication.resources.getString(R.string.unlike))
     } else {
         TPToastManager.show(TPRuntime.mainApplication.resources.getString(R.string.like))
     }
 
-    val self = this
     object : AsyncTask<Unit, Unit, Unit>() {
         override fun doInBackground(vararg args: Unit) {
             if (isLiked) {
@@ -40,26 +39,26 @@ fun Post.likeAsync(likeMsg: String, unlikeMsg: String, callback: (Post, String, 
         }
 
         override fun onPostExecute(result: Unit) {
-            callback(self, likeMsg, unlikeMsg)
+            callback(this@likeAsync)
         }
     }.execute()
 }
 
-fun Post.reblogAsync(blogName: String, msg: String, comment: String?, callback: (Post, String) -> Unit) {
-    val self = this
+fun Post.reblogAsync(blogName: String, comment: String?, callback: (Post) -> Unit) {
     TPToastManager.show(TPRuntime.mainApplication.resources.getString(R.string.reblog))
     object : AsyncTask<Unit, Unit, Unit>() {
         override fun doInBackground(vararg args: Unit) {
-            val option = mapOf<String, String>()
-            if (comment != null) {
-                option.plus(Pair("comment", comment))
+            val option = if (comment == null) {
+                emptyMap<String, String>()
+            } else {
+                mapOf("comment" to comment)
             }
             reblog(blogName, option)
             // TODO エラー処理
         }
 
         override fun onPostExecute(result: Unit) {
-            callback(self, msg)
+            callback(this@reblogAsync)
         }
     }.execute()
 }

--- a/app/src/main/kotlin/com/tumpaca/tumpaca/util/Extensions.kt
+++ b/app/src/main/kotlin/com/tumpaca/tumpaca/util/Extensions.kt
@@ -21,7 +21,7 @@ fun Context.editSharedPreferences(name: String, mode: Int = Context.MODE_PRIVATE
     assert(committed)
 }
 
-fun Post.likeAsync(callback: (Post) -> Unit) {
+fun Post.likeAsync(likeMsg: String, unlikeMsg: String, callback: (Post, String, String) -> Unit) {
     if (this.isLiked) {
         TPToastManager.show(TPRuntime.mainApplication.resources.getString(R.string.unlike))
     } else {
@@ -40,12 +40,12 @@ fun Post.likeAsync(callback: (Post) -> Unit) {
         }
 
         override fun onPostExecute(result: Unit) {
-            callback(self)
+            callback(self, likeMsg, unlikeMsg)
         }
     }.execute()
 }
 
-fun Post.reblogAsync(blogName: String, comment: String?, callback: (Post) -> Unit) {
+fun Post.reblogAsync(blogName: String, msg: String, comment: String?, callback: (Post, String) -> Unit) {
     val self = this
     TPToastManager.show(TPRuntime.mainApplication.resources.getString(R.string.reblog))
     object : AsyncTask<Unit, Unit, Unit>() {
@@ -59,7 +59,7 @@ fun Post.reblogAsync(blogName: String, comment: String?, callback: (Post) -> Uni
         }
 
         override fun onPostExecute(result: Unit) {
-            callback(self)
+            callback(self, msg)
         }
     }.execute()
 }


### PR DESCRIPTION
原因: リブログ、ライク完了後にトーストを出そうとするが、設定からダッシュボードをリロードしているとActivityが失われているため、文字列リソース取得に失敗し落ちる