### PR TITLE
未翻訳ストリングを翻訳

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,9 +82,6 @@ android {
         javaMaxHeapSize "4g"
         preDexLibraries true
     }
-    lintOptions {
-        abortOnError false
-    }
 }
 
 preBuild {

--- a/app/src/main/kotlin/com/tumpaca/tp/fragment/DashboardFragment.kt
+++ b/app/src/main/kotlin/com/tumpaca/tp/fragment/DashboardFragment.kt
@@ -170,9 +170,9 @@ class DashboardFragment : FragmentBase() {
         val errorMsg = resources.getString(R.string.error_reblog)
         currentPost
                 ?.reblogAsync(blogName, null)
-                ?.subscribe({ post ->
+                ?.subscribe({ _ ->
                     TPToastManager.show(msg)
-                }) { e ->
+                }) { _ ->
                     TPToastManager.show(errorMsg)
                 }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,7 @@
     <string translatable="false" name="adpost_ad_unit_id">ca-app-pub-5569142544566797/6481951063</string>
 
     <string translatable="false" name="settings_banner_unit_id">ca-app-pub-5569142544566797/4695553061</string>
+    <string name="cant_access_storage">Couldn’t access external storage</string>
+    <string name="download_image">Downloading…</string>
+    <string name="save_image">Save this image?</string>
 </resources>


### PR DESCRIPTION
デフォルトストリングが抜けているので日本語環境以外では画像を保存しようとするとクラッシュします。

`abortOnError false` になっていたせいでこの状態でリリースできてしまいます。この設定は自分が導入したのですが、理由は覚えていません。消すと、ストリングが抜けていてもデバッグビルドは作れて、リリースビルドが作れないのでちょうどいいと思います。