### PR TITLE
Tumpaca v1.2.0 をたちあげると落ちる。

### DIFF
--- a/app/src/main/kotlin/com/tumpaca/tp/util/DownloadUtils.kt
+++ b/app/src/main/kotlin/com/tumpaca/tp/util/DownloadUtils.kt
@@ -37,7 +37,9 @@ class DownloadUtils {
                                     BitmapFactory.decodeStream(stream, null, options)
                                 }
                             }
-                            emitter.onNext(photo)
+                            photo?.let {
+                                emitter.onNext(it)
+                            }
                             emitter.onComplete()
                         } catch (e: Exception) {
                             Log.e("downloadPhoto", e.message.orEmpty(), e)
@@ -58,7 +60,9 @@ class DownloadUtils {
                                     stream.readBytes()
                                 }
                             }
-                            emitter.onNext(gif)
+                            gif?.let {
+                                emitter.onNext(gif)
+                            }
                             emitter.onComplete()
                         } catch (e: Exception) {
                             Log.e("downloadGif", e.message.orEmpty(), e)

--- a/app/src/main/kotlin/com/tumpaca/tp/util/Extensions.kt
+++ b/app/src/main/kotlin/com/tumpaca/tp/util/Extensions.kt
@@ -46,7 +46,7 @@ fun Post.likeAsync(callback: (Post, Boolean) -> Unit) {
                     like()
                 }
                 return true
-            } catch(e: Exception) {
+            } catch (e: Exception) {
                 Log.e("LikeTask", e.message.orEmpty(), e)
                 return false
             }
@@ -69,9 +69,11 @@ fun Post.reblogAsync(blogName: String, comment: String?): Observable<Post> {
                         mapOf("comment" to comment)
                     }
                     val post = reblog(blogName, option)
-                    emitter.onNext(post)
+                    post?.let {
+                        emitter.onNext(it)
+                    }
                     emitter.onComplete()
-                } catch(e: Exception) {
+                } catch (e: Exception) {
                     Log.e("ReblogTask", e.message.orEmpty(), e)
                     emitter.onError(e)
                 }
@@ -88,9 +90,11 @@ fun Post.blogAvatar(): Observable<Bitmap?> {
                         client.blogInfo(blogName).avatar()
                     })
                     Log.d("blogAvatar", "url=" + url)
-                    emitter.onNext(url)
+                    url?.let {
+                        emitter.onNext(it)
+                    }
                     emitter.onComplete()
-                } catch(e: Exception) {
+                } catch (e: Exception) {
                     Log.e("blogAvatar", e.message.orEmpty(), e)
                     emitter.onError(e)
                 }


### PR DESCRIPTION
# 現象
アプリを開くとクラッシュします。

# スタックトレース
```
FATAL EXCEPTION: main
Process: com.tumpaca.tp, PID: 15196
java.lang.NullPointerException: onNext called with null. Null values are generally not allowed in 2.x operators and sources.
    at io.reactivex.internal.operators.observable.ObservableCreate$CreateEmitter.onNext(ObservableCreate.java:63)
    at com.tumpaca.tp.util.ExtensionsKt$blogAvatar$1.subscribe(Extensions.kt:91)
    at io.reactivex.internal.operators.observable.ObservableCreate.subscribeActual(ObservableCreate.java:40)
    at io.reactivex.Observable.subscribe(Observable.java:10685)
    at io.reactivex.internal.operators.observable.ObservableMap.subscribeActual(ObservableMap.java:32)
    at io.reactivex.Observable.subscribe(Observable.java:10685)
    at io.reactivex.internal.operators.observable.ObservableSubscribeOn$1.run(ObservableSubscribeOn.java:39)
    at io.reactivex.Scheduler$1.run(Scheduler.java:134)
    at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:59)
    at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:51)
    at java.util.concurrent.FutureTask.run(FutureTask.java:237)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:269)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
    at java.lang.Thread.run(Thread.java:818)
```

# 原因
9/8 あたりから Tumblr の blogAvator の API が HTTP のレスポンスコードとして 301 ではなく、302 を返すようになりました。その結果、次のようなパスで落ちます。

- 利用している Tumblr Java Client の Jumblr が、リダイレクトで 301 が返ってこないと Exception を吐く
    - 該当コード：https://github.com/tumblr/jumblr/blob/master/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java#L47
- Tumpaca のキャッシュ機構が例外をキャッチし、null を返す
- onNext() に null が渡るのでエラー発生
    - RxJava 2.x では onNext() に null を渡すことを許容していない。

# 修正
二つの修正をいれました。

- Jumblr 側で Redirect のレスポンスコードの判定を、「301 であること」から「3xx であること」に変更
- onNext() に null が渡らないように null チェック

前者の修正は Jumblr を fork したほうにいれました。
https://github.com/benkyokai/jumblr/commit/be123a68ac2339ae53ffd56b4b292aa6ebc22b47