### PR TITLE
Android 7 以降でダイアログのボタンが表示されていなかった問題を修正

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,5 +9,18 @@
         <item name="android:statusBarColor">@color/colorTumpaca</item>
         <item name="android:windowBackground">@color/colorTumpaca</item>
         <item name="android:textColor">#fafafa</item>
+        <item name="android:alertDialogTheme">@style/AlertDialogTheme</item>
+        <item name="alertDialogTheme">@style/AlertDialogTheme</item>
+    </style>
+
+    <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="buttonBarButtonStyle">@style/DialogButtonStyle</item>
+    </style>
+
+    <style name="DialogButtonStyle" parent="@style/Widget.AppCompat.Button.ButtonBar.AlertDialog">
+        <item name="android:textColor">@color/colorAccent</item>
     </style>
 </resources>


### PR DESCRIPTION
Android 7 以降でダイアログのボタンが表示されていなかった問題を直しました。

Android 7.1 と 8.0 で修正確認しました。